### PR TITLE
feat: #150 New view to select deploy action and domain

### DIFF
--- a/src/api/apiTypes.ts
+++ b/src/api/apiTypes.ts
@@ -13,6 +13,7 @@ export type Chain = BaseEntity & {
   elements: Element[];
   dependencies: Dependency[];
   deployments: Deployment[];
+  deployAction?: ChainCommitRequestAction;
   labels: EntityLabel[];
   defaultSwimlaneId: string;
   reuseSwimlaneId: string;

--- a/src/pages/ChainExtensionProperties.tsx
+++ b/src/pages/ChainExtensionProperties.tsx
@@ -1,0 +1,64 @@
+import { isVsCode } from "../api/rest/vscodeExtensionApi";
+import { Form, Input, Select, SelectProps } from "antd";
+import { Chain, ChainCommitRequestAction, Deployment } from "../api/apiTypes";
+import { capitalize } from "../misc/format-utils";
+import { ChainContextData } from "./ChainPage";
+import { FormData } from "./ChainProperties";
+
+export const loadChainExtensionPropertiesToForm = (
+  source: ChainContextData,
+  target: FormData,
+): void => {
+  if (isVsCode && source?.chain) {
+    target.domain =
+      (source.chain.deployments?.length ?? 0 > 0)
+        ? source.chain.deployments[0].domain
+        : undefined;
+    target.deployAction = source.chain.deployAction;
+  }
+};
+
+export const readChainExtensionPropertiesFromForm = (
+  source: FormData,
+  target: Partial<Chain>,
+): void => {
+  if (isVsCode) {
+    const deployAction =
+      source.deployAction !== undefined
+        ? ChainCommitRequestAction[
+            source.deployAction as keyof typeof ChainCommitRequestAction
+          ]
+        : undefined;
+
+    target.deployments = [{ domain: source.domain } as Deployment];
+    target.deployAction = deployAction;
+  }
+};
+
+type Props = {
+  onChange: () => void;
+};
+
+export const ChainExtensionProperties: React.FC<Props> = (props) => {
+  if (isVsCode) {
+    const deployActionOptions: SelectProps["options"] =
+      Object.keys(ChainCommitRequestAction)?.map((key) => ({
+        label: capitalize(key),
+        value: key,
+      })) ?? [];
+
+    return (
+      <span>
+        <Form.Item label="Domain" name="domain">
+          <Input defaultValue="default" />
+        </Form.Item>
+        <Form.Item label="Deploy Action" name="deployAction">
+          {/* eslint-disable-next-line react/prop-types */}
+          <Select options={deployActionOptions} onChange={props.onChange} />
+        </Form.Item>
+      </span>
+    );
+  } else {
+    return <></>;
+  }
+};

--- a/src/pages/ChainPage.tsx
+++ b/src/pages/ChainPage.tsx
@@ -7,6 +7,7 @@ import { createContext, useEffect, useState } from "react";
 import { Chain } from "../api/apiTypes.ts";
 import { BreadcrumbProps } from "antd/es/breadcrumb/Breadcrumb";
 import { HomeOutlined } from "@ant-design/icons";
+import { isVsCode } from "../api/rest/vscodeExtensionApi.ts";
 
 export type ChainContextData = {
   chain: Chain | undefined;
@@ -113,14 +114,14 @@ const ChainPage = () => {
           >
             <Radio.Button value="graph">Graph</Radio.Button>
             <Radio.Button value="snapshots">Snapshots</Radio.Button>
-            <Radio.Button value="deployments">Deployments</Radio.Button>
+            {isVsCode ? (
+              <></>
+            ) : (
+              <Radio.Button value="deployments">Deployments</Radio.Button>
+            )}
             <Radio.Button value="sessions">Sessions</Radio.Button>
-            <Radio.Button value="logging-settings">
-              Logging
-            </Radio.Button>
-            <Radio.Button value="masking">
-              Masking
-            </Radio.Button>
+            <Radio.Button value="logging-settings">Logging</Radio.Button>
+            <Radio.Button value="masking">Masking</Radio.Button>
             <Radio.Button value="properties">Properties</Radio.Button>
           </Radio.Group>
         </Col>

--- a/src/pages/ChainProperties.tsx
+++ b/src/pages/ChainProperties.tsx
@@ -4,14 +4,17 @@ import TextArea from "antd/lib/input/TextArea";
 import { Chain } from "../api/apiTypes.ts";
 import { useForm } from "antd/lib/form/Form";
 import { ChainContext } from "./ChainPage.tsx";
+import { ChainExtensionProperties, loadChainExtensionPropertiesToForm, readChainExtensionPropertiesFromForm } from "./ChainExtensionProperties.tsx";
 
-type FormData = {
+export type FormData = {
   name: string;
   labels: string[];
   description: string;
   businessDescription: string;
   assumptions: string;
   outOfScope: string;
+  domain?: string;
+  deployAction?: string;
 };
 
 export const ChainProperties: React.FC = () => {
@@ -23,7 +26,7 @@ export const ChainProperties: React.FC = () => {
 
   useEffect(() => {
     if (chainContext?.chain) {
-      const formData = {
+      const formData: FormData = {
         name: chainContext.chain.name,
         labels: chainContext.chain.labels.map((label) => label.name),
         description: chainContext.chain.description,
@@ -31,6 +34,7 @@ export const ChainProperties: React.FC = () => {
         assumptions: chainContext.chain.assumptions,
         outOfScope: chainContext.chain.outOfScope,
       };
+      loadChainExtensionPropertiesToForm(chainContext, formData);
       form.setFieldsValue(formData);
     }
   }, [chainContext, form]);
@@ -56,6 +60,7 @@ export const ChainProperties: React.FC = () => {
             assumptions: values.assumptions,
             outOfScope: values.outOfScope,
           };
+          readChainExtensionPropertiesFromForm(values, changes);
           setIsUpdating(true);
           void chainContext
             .update(changes)
@@ -88,6 +93,7 @@ export const ChainProperties: React.FC = () => {
       <Form.Item label="Out of Scope" name="outOfScope">
         <TextArea style={{ height: 120, resize: "none" }} />
       </Form.Item>
+      <ChainExtensionProperties onChange={() => setHasChanges(true)}/>
       <Button
         type="primary"
         htmlType="submit"


### PR DESCRIPTION
[Extension PR](https://github.com/Netcracker/qubership-integration-vscode-extension/pull/5) required to be merged as well

Changes on Chain view (only for extension):
- Deployments tab removed
- Properties tab extended with Domain and Deploy Action fields

<img width="1545" height="969" alt="properties-extension" src="https://github.com/user-attachments/assets/d6bbe237-ad9b-44af-a03d-a9134f0aa919" />
