### PR TITLE
feat(ui): add "Skip empty query parameters" checkbox in Query Parameters table

### DIFF
--- a/src/components/modal/chain_element/ChainElementModification.tsx
+++ b/src/components/modal/chain_element/ChainElementModification.tsx
@@ -96,6 +96,7 @@ export type FormContext = {
   integrationSpecificationGroupId?: string;
   integrationSpecificationId?: string;
   systemType?: string;
+  integrationOperationSkipEmptyQueryParameters?: boolean;
   bodyFormData?: BodyFormEntry[];
   synchronousGrpcCall?: boolean;
   chainId?: string;
@@ -227,6 +228,7 @@ export const ChainElementModification: React.FC<ElementModificationProps> = ({
         bodyFormData: toBodyFormData(formProperties.bodyFormData),
         synchronousGrpcCall: Boolean(formProperties.synchronousGrpcCall),
         chainId: chainId,
+        integrationOperationSkipEmptyQueryParameters: formProperties.integrationOperationSkipEmptyQueryParameters as boolean | undefined,
         updateContext: (updatedProperties: Record<string, unknown>) => {
           if (
             updatedProperties.integrationOperationProtocolType !== undefined

--- a/src/components/modal/chain_element/ChainElementModificationConstants.ts
+++ b/src/components/modal/chain_element/ChainElementModificationConstants.ts
@@ -305,6 +305,9 @@ export const INITIAL_UI_SCHEMA: UiSchema = {
     integrationSpecificationGroupId: {
       "ui:widget": "hidden",
     },
+    integrationOperationSkipEmptyQueryParameters: {
+      "ui:widget": "hidden",
+    },
     elementId: {
       "ui:field": "singleSelectField",
     },

--- a/src/components/modal/chain_element/field/EnhancedPatternPropertiesField.module.css
+++ b/src/components/modal/chain_element/field/EnhancedPatternPropertiesField.module.css
@@ -131,3 +131,7 @@
   width: 32px;
 }
 
+.checkboxRow {
+  padding: 12px 4px;
+}
+

--- a/src/components/modal/chain_element/field/EnhancedPatternPropertiesField.tsx
+++ b/src/components/modal/chain_element/field/EnhancedPatternPropertiesField.tsx
@@ -5,6 +5,7 @@ import styles from "./EnhancedPatternPropertiesField.module.css";
 import { OverridableIcon } from "../../../../icons/IconProvider.tsx";
 import { FormContext } from "../ChainElementModification";
 import { api } from "../../../../api/api";
+import { QueryParametersCheckbox } from "./QueryParametersCheckbox";
 import {
   isAmqpProtocol,
   isKafkaProtocol,
@@ -592,82 +593,91 @@ const EnhancedPatternPropertiesField: React.FC<EnhancedFieldProps> = ({
             No entries. Click <b>+</b> to add.
           </div>
         ) : (
-          <table className={styles.table}>
-            <thead>
-              <tr>
-                <th className={styles.th}>Name</th>
-                <th className={styles.th}>Value</th>
-                <th className={styles.th}></th>
-              </tr>
-            </thead>
-            <tbody>
-              {mergedParameters.map((param, idx) => {
-                const displayedValue = localValues[param.name] ?? param.value;
-                const hasValue =
-                  displayedValue !== undefined &&
-                  String(displayedValue).trim().length > 0;
-                const rowClass =
-                  param.required && !hasValue ? styles.requiredRow : '';
+          <>
+            <table className={styles.table}>
+              <thead>
+                <tr>
+                  <th className={styles.th}>Name</th>
+                  <th className={styles.th}>Value</th>
+                  <th className={styles.th}></th>
+                </tr>
+              </thead>
+              <tbody>
+                {mergedParameters.map((param, idx) => {
+                  const displayedValue = localValues[param.name] ?? param.value;
+                  const hasValue =
+                    displayedValue !== undefined &&
+                    String(displayedValue).trim().length > 0;
+                  const rowClass =
+                    param.required && !hasValue ? styles.requiredRow : '';
 
-                return (
-                  <tr key={idx} className={rowClass}>
-                  <td className={styles.td}>
-                    <div className={styles.nameCell}>
-                      {param.canDelete && param.source === 'custom' ? (
-                        <Input
-                          value={param.name}
-                          onChange={(e) => handleKeyChange(param.name, e.target.value)}
-                          disabled={disabled || readonly}
-                          placeholder="Name"
-                        />
-                      ) : (
-                        <span className={styles.paramName}>{param.name}</span>
-                      )}
-                      {(param.isOverridden || param.deprecated) && (
-                        <div className={styles.labels}>
-                          {param.isOverridden && <Tag className={styles.overriddenTag}>Overridden</Tag>}
-                          {param.deprecated && <Tag className={styles.deprecatedTag}>Deprecated</Tag>}
-                        </div>
-                      )}
-                    </div>
-                  </td>
-                  <td className={styles.td}>
-                    <Input
-                      value={localValues[param.name] ?? param.value}
-                      onChange={(e) => handleValueChange(param.name, e.target.value)}
-                      disabled={disabled || readonly}
-                      placeholder="Value"
-                    />
-                  </td>
-                  <td className={styles.td}>
-                    <div className={styles.actions}>
-                      {param.isOverridden && !disabled && !readonly && (
-                        <Tooltip title="Restore default value">
+                  return (
+                    <tr key={idx} className={rowClass}>
+                    <td className={styles.td}>
+                      <div className={styles.nameCell}>
+                        {param.canDelete && param.source === 'custom' ? (
+                          <Input
+                            value={param.name}
+                            onChange={(e) => handleKeyChange(param.name, e.target.value)}
+                            disabled={disabled || readonly}
+                            placeholder="Name"
+                          />
+                        ) : (
+                          <span className={styles.paramName}>{param.name}</span>
+                        )}
+                        {(param.isOverridden || param.deprecated) && (
+                          <div className={styles.labels}>
+                            {param.isOverridden && <Tag className={styles.overriddenTag}>Overridden</Tag>}
+                            {param.deprecated && <Tag className={styles.deprecatedTag}>Deprecated</Tag>}
+                          </div>
+                        )}
+                      </div>
+                    </td>
+                    <td className={styles.td}>
+                      <Input
+                        value={localValues[param.name] ?? param.value}
+                        onChange={(e) => handleValueChange(param.name, e.target.value)}
+                        disabled={disabled || readonly}
+                        placeholder="Value"
+                      />
+                    </td>
+                    <td className={styles.td}>
+                      <div className={styles.actions}>
+                        {param.isOverridden && !disabled && !readonly && (
+                          <Tooltip title="Restore default value">
+                            <Button
+                              size="small"
+                              type="text"
+                              icon={<OverridableIcon name="rollback" />}
+                              onClick={() => restoreDefaultValue(param.name)}
+                              className={styles.restoreBtn}
+                            />
+                          </Tooltip>
+                        )}
+                        {param.canDelete && !disabled && !readonly && (
                           <Button
                             size="small"
                             type="text"
-                            icon={<OverridableIcon name="rollback" />}
-                            onClick={() => restoreDefaultValue(param.name)}
-                            className={styles.restoreBtn}
+                            icon={<OverridableIcon name="delete" />}
+                            onClick={() => handleDelete(param.name)}
+                            className={styles.deleteBtn}
                           />
-                        </Tooltip>
-                      )}
-                      {param.canDelete && !disabled && !readonly && (
-                        <Button
-                          size="small"
-                          type="text"
-                          icon={<OverridableIcon name="delete" />}
-                          onClick={() => handleDelete(param.name)}
-                          className={styles.deleteBtn}
-                        />
-                      )}
-                    </div>
-                  </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
+                        )}
+                      </div>
+                    </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+            {paramType === 'query' && formContext?.integrationOperationProtocolType?.toLowerCase() === 'http' && (
+              <QueryParametersCheckbox
+                formContext={formContext}
+                disabled={disabled}
+                readonly={readonly}
+              />
+            )}
+          </>
         ))}
     </div>
   );

--- a/src/components/modal/chain_element/field/QueryParametersCheckbox.tsx
+++ b/src/components/modal/chain_element/field/QueryParametersCheckbox.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { Checkbox } from "antd";
+import { FormContext } from "../ChainElementModification";
+import styles from "./EnhancedPatternPropertiesField.module.css";
+
+interface QueryParametersCheckboxProps {
+    formContext?: FormContext;
+    disabled?: boolean;
+    readonly?: boolean;
+}
+
+export const QueryParametersCheckbox: React.FC<QueryParametersCheckboxProps> = ({
+    formContext,
+    disabled,
+    readonly,
+}) => {
+    const checked = formContext?.integrationOperationSkipEmptyQueryParameters ?? false;
+
+    const handleChange = (newValue: boolean) => {
+        formContext?.updateContext?.({
+            integrationOperationSkipEmptyQueryParameters: newValue,
+        });
+    };
+
+    return (
+        <div className={styles.checkboxRow}>
+            <Checkbox
+                checked={checked}
+                onChange={(e) => handleChange(e.target.checked)}
+                disabled={disabled || readonly}
+            >
+                Skip empty query parameters
+            </Checkbox>
+        </div>
+    );
+};
+


### PR DESCRIPTION
Adds a "Skip empty query parameters" checkbox to the Query Parameters table for HTTP service call operations. When enabled, empty and null query parameters will be excluded from the HTTP request URL.

- Add new QueryParametersCheckbox component for skip empty query parameters functionality
- Integrate QueryParametersCheckbox into EnhancedPatternPropertiesField below query parameters table
- Add integrationOperationSkipEmptyQueryParameters to FormContext
- Add UI schema configuration for the new field
- Add checkboxRow CSS class for styling the checkbox component
<img width="1148" height="617" alt="image" src="https://github.com/user-attachments/assets/e716f40d-4638-42d6-b813-3ac5cfbb4d35" />
