### PR TITLE
fix: #390, #391 External config loading fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "build:lib": "vite build --config vite.config.lib.ts",
     "build:lib:external": "vite build --config vite.config.lib.ts",
     "build:lib:bundled": "vite build --config vite.config.lib.bundled.ts",
-    "build:lib:all": "npm run build:lib:external && npm run build:lib:bundled",
+    "build:lib:all": "npm run build:lib:external && npm run build:lib:bundled && node scripts/fix-preload.js",
     "fetch-docs": "ts-node --project scripts/tsconfig.json scripts/fetch-documentation.ts",
     "build:doc-index": "node scripts/build-doc-index.js",
     "check-types": "tsc --noEmit",

--- a/src/icons/IconProvider.tsx
+++ b/src/icons/IconProvider.tsx
@@ -9,7 +9,7 @@ import Icon from "@ant-design/icons";
 import type { AntdIconProps } from "@ant-design/icons/lib/components/AntdIcon";
 import parse from "html-react-parser";
 import { commonIcons, elementIcons } from "./IconDefenitions";
-import { getConfig } from "../appConfig.ts";
+import { getConfig, onConfigChange } from "../appConfig.ts";
 
 export type IconSource =
   | React.ComponentType<AntdIconProps>
@@ -84,10 +84,17 @@ export const IconProvider: React.FC<{ children: ReactNode }> = ({
   });
 
   useEffect(() => {
-    const config = getConfig();
-    if (config.icons) {
-      setIconsState((prev) => ({ ...allIcons, ...prev, ...config.icons }));
-    }
+    const applyConfig = (cfg: ReturnType<typeof getConfig>) => {
+      if (cfg.icons) {
+        setIconsState(() => ({ ...allIcons, ...cfg.icons }));
+      } else {
+        setIconsState(() => allIcons);
+      }
+    };
+
+    applyConfig(getConfig());
+    const unsubscribe = onConfigChange((cfg) => applyConfig(cfg));
+    return unsubscribe;
   }, []);
 
   const setIcons = (overrides: IconOverrides) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ export {
   loadConfigFromJson,
   configure,
   getConfig,
+  onConfigChange,
   mergeConfigWithEnv,
   isDev,
 } from "./appConfig";


### PR DESCRIPTION
closes #390 #391 
- Made icon overrides apply reliably by notifying IconProvider on config updates and merging icon overrides in configure().
- Ensured the library build runs the preload-fix step to prevent downstream bundling issues.

I have read the CLA Document and I hereby sign the CLA