### PR TITLE
fix: fix mapper and script not appearing in element parameters

### DIFF
--- a/src/components/modal/chain_element/ChainElementModificationConstants.ts
+++ b/src/components/modal/chain_element/ChainElementModificationConstants.ts
@@ -579,7 +579,11 @@ export const pathToTabMap: Record<string, string> = {
   "properties.idempotency.chainTriggerParameters.chainCallTimeout":
     "Idempotency",
   "properties.before": "Prepare Request",
+  "properties.before.script": "Prepare Request",
+  "properties.before.mappingDescription": "Prepare Request",
   "properties.after": "Handle Response",
+  "properties.after.items.script": "Handle Response",
+  "properties.after.items.mappingDescription": "Handle Response",
   "properties.afterValidation": "Validations",
   "properties.requestFilterHeaderAllowlist": "Filter Request",
   "properties.logLevel": "Logging",


### PR DESCRIPTION
closes #421 
- Added missing path mappings in `pathToTabMap` for nested `script` and `mappingDescription` inside `before` and `after` properties.
