### PR TITLE
fix(maas): use legacy api base for MaaS actions URLs

### DIFF
--- a/src/api/rest/restApi.ts
+++ b/src/api/rest/restApi.ts
@@ -160,6 +160,7 @@ export class RestApi implements Api {
     );
   }
 
+  private readonly newV1 = (): string => `/api/${getAppName()}/v1`;
   private readonly v1 = (): string => `/api/v1/${getAppName()}`;
   private readonly v2 = (): string => `/api/${getAppName()}/v2`;
   private readonly v3 = (): string => `/api/${getAppName()}/v3`;
@@ -1956,7 +1957,7 @@ export class RestApi implements Api {
   createMaasKafkaEntity = async (
     request: CreateMaasKafkaRequest,
   ): Promise<void> => {
-    await this.instance.post(`${this.v1()}/maas-actions/kafka`, undefined, {
+    await this.instance.post(`${this.newV1()}/maas-actions/kafka`, undefined, {
       params: {
         namespace: request.namespace,
         topicClassifierName: request.topicClassifierName,
@@ -1967,22 +1968,26 @@ export class RestApi implements Api {
   createMaasRabbitMQEntity = async (
     request: CreateMaasRabbitMQRequest,
   ): Promise<void> => {
-    await this.instance.post(`${this.v1()}/maas-actions/rabbitmq`, undefined, {
-      params: {
-        namespace: request.namespace,
-        vhost: request.vhost,
-        exchange: request.exchange,
-        queue: request.queue,
-        routingKey: request.routingKey,
+    await this.instance.post(
+      `${this.newV1()}/maas-actions/rabbitmq`,
+      undefined,
+      {
+        params: {
+          namespace: request.namespace,
+          vhost: request.vhost,
+          exchange: request.exchange,
+          queue: request.queue,
+          routingKey: request.routingKey,
+        },
       },
-    });
+    );
   };
 
   getMaasKafkaDeclarativeFile = async (
     request: GetMaasKafkaDeclarativeRequest,
   ): Promise<File> => {
     const response = await this.instance.post<Blob>(
-      `${this.v1()}/maas-actions/kafka/declarative`,
+      `${this.newV1()}/maas-actions/kafka/declarative`,
       undefined,
       {
         params: { topicClassifierName: request.topicClassifierName },
@@ -1996,7 +2001,7 @@ export class RestApi implements Api {
     request: GetMaasRabbitMQDeclarativeRequest,
   ): Promise<File> => {
     const response = await this.instance.post<Blob>(
-      `${this.v1()}/maas-actions/rabbitmq/declarative`,
+      `${this.newV1()}/maas-actions/rabbitmq/declarative`,
       undefined,
       {
         params: {

--- a/tests/api/rest/restApi.maas.test.ts
+++ b/tests/api/rest/restApi.maas.test.ts
@@ -87,9 +87,11 @@ describe("RestApi MaaS", () => {
   });
 
   it("getMaasKafkaDeclarativeFile sends POST and returns File", async () => {
+    let lastUrl = "";
     const { RestApi } = await import("../../../src/api/rest/restApi");
     const api = new RestApi();
     api.instance.defaults.adapter = (async (config: AxiosRequestConfig) => {
+      lastUrl = config.url ?? "";
       const blob = new Blob(["declarative json"]);
       return {
         data: blob,
@@ -111,15 +113,18 @@ describe("RestApi MaaS", () => {
       topicClassifierName: "my-classifier",
     });
 
+    expect(lastUrl).toContain("/maas-actions/kafka/declarative");
     expect(result).toBeInstanceOf(File);
     expect(result.name).toBe("kafka-declarative.json");
   });
 
   it("getMaasRabbitMQDeclarativeFile sends POST with params and returns File", async () => {
+    let lastUrl = "";
     let lastParams: Record<string, string | undefined> | undefined;
     const { RestApi } = await import("../../../src/api/rest/restApi");
     const api = new RestApi();
     api.instance.defaults.adapter = (async (config: AxiosRequestConfig) => {
+      lastUrl = config.url ?? "";
       lastParams = config.params as
         | Record<string, string | undefined>
         | undefined;
@@ -147,6 +152,7 @@ describe("RestApi MaaS", () => {
       routingKey: "routing.key",
     });
 
+    expect(lastUrl).toContain("/maas-actions/rabbitmq/declarative");
     expect(lastParams).toEqual({
       vhost: "public",
       exchange: "ex",


### PR DESCRIPTION
Build MaaS paths as `${newV1()}/maas-actions/...` so they match
`/api/{app}/v1/maas-actions/*` like other app-scoped versioned routes, so that they point to legacy urls.

RestApi MaaS tests still assert only the `/maas-actions/...` path segments.