### PR TITLE
fix: Fixed icons

### DIFF
--- a/src/icons/IconDefenitions.tsx
+++ b/src/icons/IconDefenitions.tsx
@@ -125,6 +125,7 @@ import {
   ClockCircleOutlined,
   MinusCircleOutlined,
   SyncOutlined,
+  ColumnWidthOutlined,
 } from "@ant-design/icons";
 
 /**
@@ -269,6 +270,7 @@ export const commonIcons = {
   deploymentStatusDraft: ClockCircleOutlined,
   documentationSearchResult: FileTextOutlined,
   compare: DiffOutlined,
+  diagram: ColumnWidthOutlined,
 };
 
 export const elementIcons = {

--- a/src/icons/IconDefenitions.tsx
+++ b/src/icons/IconDefenitions.tsx
@@ -268,6 +268,7 @@ export const commonIcons = {
   deploymentStatusRemoved: MinusCircleOutlined,
   deploymentStatusDraft: ClockCircleOutlined,
   documentationSearchResult: FileTextOutlined,
+  compare: DiffOutlined,
 };
 
 export const elementIcons = {

--- a/src/pages/ChainGraph.tsx
+++ b/src/pages/ChainGraph.tsx
@@ -473,15 +473,7 @@ const ChainGraphInner: React.FC = () => {
           require={{ chain: ["read"] }}
           tooltipProps={{ title: "Show sequence diagram" }}
           buttonProps={{
-            icon: (
-              <span
-                className={String(styles.sequenceDiagramIcon ?? "")}
-                data-icon="sequence-diagram"
-                role="img"
-              >
-                ⇄
-              </span>
-            ),
+            iconName: "diagram",
             onClick: openSequenceDiagram,
           }}
         />

--- a/src/pages/Chains.tsx
+++ b/src/pages/Chains.tsx
@@ -1168,7 +1168,7 @@ const Chains = () => {
                   title: "Compare selected chains",
                   placement: "bottom",
                 }}
-                buttonProps={{ icon: <>⇄</>, disabled: true }}
+                buttonProps={{ iconName: "compare", disabled: true }}
               />
               <ProtectedButton
                 require={{ chain: ["create"] }}

--- a/src/pages/Snapshots.tsx
+++ b/src/pages/Snapshots.tsx
@@ -439,7 +439,7 @@ export const Snapshots: React.FC = () => {
             require={{ snapshot: ["read"] }}
             tooltipProps={{ title: "Compare selected snapshots" }}
             buttonProps={{
-              icon: <>⇄</>,
+              iconName: "compare",
               onClick: onCompareBtnClick,
               disabled: selectedRowKeys.length !== 2,
             }}

--- a/src/pages/Snapshots.tsx
+++ b/src/pages/Snapshots.tsx
@@ -350,7 +350,7 @@ export const Snapshots: React.FC = () => {
                 },
                 {
                   key: "showDiagram",
-                  icon: <span className="anticon">⭾</span>,
+                  icon: <OverridableIcon name="diagram" />,
                   label: "Show diagram",
                   onClick: () => showSnapshotDiagram(snapshot),
                   require: { snapshot: ["read"] },


### PR DESCRIPTION
Icons for compare action and sequence diagram are changed to icons from Ant Design library.

closes https://github.com/Netcracker/qubership-integration-platform/issues/115