### PR TITLE
fix(ui): hide row-actions column from column picker (#653)

### DIFF
--- a/src/components/table/ColumnsFilter.tsx
+++ b/src/components/table/ColumnsFilter.tsx
@@ -2,7 +2,36 @@ import React, { useEffect, useState } from "react";
 import { Button, Checkbox } from "antd";
 import { ReactSortable } from "react-sortablejs";
 import { parseJsonOrDefault } from "../../misc/json-helper";
+import { ACTIONS_COLUMN_KEY } from "./actionsColumn";
 import { clearColumnMetadata, isColumnVisibilityLocked } from "./useColumnSettingsButton";
+
+const COLUMN_KEYS_EXCLUDED_FROM_PICKER = new Set<string>([
+  ACTIONS_COLUMN_KEY,
+]);
+
+const NON_TOGGLEABLE_VISIBILITY_KEYS = new Set<string>(["name"]);
+
+function isVisibilityToggleDisabled(columnKey: string): boolean {
+  return (
+    NON_TOGGLEABLE_VISIBILITY_KEYS.has(columnKey) ||
+    isColumnVisibilityLocked(columnKey)
+  );
+}
+
+type SortablePickerItem = { id: unknown };
+
+function applyPickerColumnReorder(
+  setColumnsOrder: React.Dispatch<React.SetStateAction<string[]>>,
+  newList: readonly SortablePickerItem[],
+): void {
+  const reordered = newList.map((item) => String(item.id));
+  setColumnsOrder((prev) => {
+    const tail = prev.filter((k) =>
+      COLUMN_KEYS_EXCLUDED_FROM_PICKER.has(k),
+    );
+    return [...reordered, ...tail];
+  });
+}
 
 export interface ColumnFilterProps {
   allColumns: string[];
@@ -80,6 +109,11 @@ export const ColumnsFilter: React.FC<ColumnFilterProps> = ({
     if (typeof fromMap === "string" && fromMap.length > 0) return fromMap;
     return humanizeKey(key);
   };
+
+  const columnOrderForPicker = columnsOrder.filter(
+    (key) => !COLUMN_KEYS_EXCLUDED_FROM_PICKER.has(key),
+  );
+
   return (
     <div
       style={{
@@ -92,14 +126,14 @@ export const ColumnsFilter: React.FC<ColumnFilterProps> = ({
       }}
     >
       <ReactSortable
-        list={columnsOrder.map((id) => ({ id }))}
+        list={columnOrderForPicker.map((id) => ({ id }))}
         setList={(newList) =>
-          setColumnsOrder(newList.map((item) => String(item.id)))
+          applyPickerColumnReorder(setColumnsOrder, newList)
         }
         animation={150}
         handle=".drag-handle"
       >
-        {columnsOrder.map((key) => (
+        {columnOrderForPicker.map((key) => (
           <div
             key={key}
             style={{
@@ -130,7 +164,7 @@ export const ColumnsFilter: React.FC<ColumnFilterProps> = ({
               ≡
             </span>
             <Checkbox
-              disabled={key === "name" || isColumnVisibilityLocked(key)}
+              disabled={isVisibilityToggleDisabled(key)}
               checked={visibleColumns.includes(key)}
               onChange={(e) => {
                 if (e.target.checked) {

--- a/tests/components/table/ColumnsFilter.test.tsx
+++ b/tests/components/table/ColumnsFilter.test.tsx
@@ -1,0 +1,193 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import {
+  ColumnsFilter,
+  getColumnsOrderKey,
+  getColumnsVisibleKey,
+} from "../../../src/components/table/ColumnsFilter";
+import { ACTIONS_COLUMN_KEY } from "../../../src/components/table/actionsColumn";
+
+jest.mock("react-sortablejs", () => ({
+  ReactSortable: ({
+    children,
+    setList,
+    list,
+  }: {
+    children: React.ReactNode;
+    setList: (next: { id: string }[]) => void;
+    list: { id: string }[];
+  }) => (
+    <div data-testid="sortable-mock">
+      <button
+        type="button"
+        data-testid="simulate-picker-reorder"
+        onClick={() => {
+          const ids = list.map((item) => String(item.id));
+          setList([...ids].reverse().map((id) => ({ id })));
+        }}
+      >
+        simulate reorder
+      </button>
+      {children}
+    </div>
+  ),
+}));
+
+const STORAGE_KEY = "columnsFilterTest";
+
+beforeEach(() => {
+  localStorage.removeItem(getColumnsOrderKey(STORAGE_KEY));
+  localStorage.removeItem(getColumnsVisibleKey(STORAGE_KEY));
+});
+
+describe("ColumnsFilter key helpers", () => {
+  it("getColumnsOrderKey appends _columnsOrder", () => {
+    expect(getColumnsOrderKey("myTable")).toBe("myTable_columnsOrder");
+  });
+
+  it("getColumnsVisibleKey appends _columnsVisible", () => {
+    expect(getColumnsVisibleKey("myTable")).toBe("myTable_columnsVisible");
+  });
+});
+
+describe("ColumnsFilter", () => {
+  const allColumns = ["name", "protocol", "status", ACTIONS_COLUMN_KEY];
+  const defaultColumns = ["name", "protocol", "status"];
+
+  it("does not list the actions key in the picker (excluded from picker keys)", () => {
+    const onChange = jest.fn();
+    render(
+      <ColumnsFilter
+        allColumns={allColumns}
+        defaultColumns={defaultColumns}
+        storageKey={STORAGE_KEY}
+        onChange={onChange}
+      />,
+    );
+    expect(screen.queryByRole("checkbox", { name: /actions/i })).toBeNull();
+    expect(screen.getByRole("checkbox", { name: /protocol/i })).toBeInTheDocument();
+  });
+
+  it("disables the name column checkbox", () => {
+    const onChange = jest.fn();
+    render(
+      <ColumnsFilter
+        allColumns={allColumns}
+        defaultColumns={defaultColumns}
+        storageKey={STORAGE_KEY}
+        onChange={onChange}
+      />,
+    );
+    expect(screen.getByRole("checkbox", { name: /^name$/i })).toBeDisabled();
+  });
+
+  it("uses labelsByKey for checkbox labels when provided", () => {
+    const onChange = jest.fn();
+    render(
+      <ColumnsFilter
+        allColumns={["name", "protocol"]}
+        defaultColumns={["name", "protocol"]}
+        storageKey={STORAGE_KEY}
+        onChange={onChange}
+        labelsByKey={{ protocol: "Proto X" }}
+      />,
+    );
+    expect(screen.getByRole("checkbox", { name: "Proto X" })).toBeInTheDocument();
+  });
+
+  it("disables checkbox for visibility-locked keys (suffix *)", () => {
+    const onChange = jest.fn();
+    render(
+      <ColumnsFilter
+        allColumns={["name", "lockedCol*"]}
+        defaultColumns={["name", "lockedCol*"]}
+        storageKey={STORAGE_KEY}
+        onChange={onChange}
+      />,
+    );
+    expect(screen.getByRole("checkbox", { name: /locked col/i })).toBeDisabled();
+  });
+
+  it("updates visibility when a toggleable column is unchecked", async () => {
+    const onChange = jest.fn();
+    render(
+      <ColumnsFilter
+        allColumns={allColumns}
+        defaultColumns={defaultColumns}
+        storageKey={STORAGE_KEY}
+        onChange={onChange}
+      />,
+    );
+    const protocol = screen.getByRole("checkbox", { name: /protocol/i });
+    expect(protocol).toBeChecked();
+    fireEvent.click(protocol);
+    await waitFor(() => {
+      expect(protocol).not.toBeChecked();
+    });
+    expect(onChange).toHaveBeenCalled();
+    const lastCall =
+      onChange.mock.calls[onChange.mock.calls.length - 1] as [
+        string[],
+        string[],
+      ];
+    expect(lastCall[1]).not.toContain("protocol");
+  });
+
+  it("reset restores order and visibility from props", async () => {
+    const onChange = jest.fn();
+    localStorage.setItem(
+      getColumnsOrderKey(STORAGE_KEY),
+      JSON.stringify(["status", "protocol", "name", ACTIONS_COLUMN_KEY]),
+    );
+    localStorage.setItem(
+      getColumnsVisibleKey(STORAGE_KEY),
+      JSON.stringify(["name"]),
+    );
+    render(
+      <ColumnsFilter
+        allColumns={allColumns}
+        defaultColumns={defaultColumns}
+        storageKey={STORAGE_KEY}
+        onChange={onChange}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /reset/i }));
+    await waitFor(() => {
+      expect(JSON.parse(localStorage.getItem(getColumnsOrderKey(STORAGE_KEY))!)).toEqual(
+        allColumns,
+      );
+    });
+    expect(JSON.parse(localStorage.getItem(getColumnsVisibleKey(STORAGE_KEY))!)).toEqual(
+      defaultColumns,
+    );
+  });
+
+  it("merges picker reorder with excluded tail keys (e.g. actions)", async () => {
+    const onChange = jest.fn();
+    render(
+      <ColumnsFilter
+        allColumns={allColumns}
+        defaultColumns={defaultColumns}
+        storageKey={STORAGE_KEY}
+        onChange={onChange}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("simulate-picker-reorder"));
+    await waitFor(() => {
+      const stored = JSON.parse(
+        localStorage.getItem(getColumnsOrderKey(STORAGE_KEY))!,
+      ) as string[];
+      expect(stored).toEqual([
+        "status",
+        "protocol",
+        "name",
+        ACTIONS_COLUMN_KEY,
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
- Exclude actions col key from ColumnsFilter so Actions is not listed in Properties.
- Preserve full column order by merging picker reorder with excluded keys (applyPickerColumnReorder).