### PR TITLE
fix(audit): lock Audit Action Time in column settings (#652)

### DIFF
--- a/src/components/admin_tools/ActionsLog.tsx
+++ b/src/components/admin_tools/ActionsLog.tsx
@@ -8,7 +8,6 @@ import {
   Table,
   Tooltip,
 } from "antd";
-import { TableProps } from "antd/lib/table";
 import React, { UIEvent, useMemo, useRef, useState } from "react";
 import { useActionLog } from "../../hooks/useActionLog.tsx";
 import {
@@ -32,7 +31,10 @@ import { useResizeHeight } from "../../hooks/useResizeHeigth.tsx";
 import commonStyles from "./CommonStyle.module.css";
 import { OverridableIcon } from "../../icons/IconProvider.tsx";
 import { Require } from "../../permissions/Require.tsx";
-import { useColumnSettingsBasedOnColumnsType } from "../table/useColumnSettingsButton.tsx";
+import {
+  ColumnsTypeWithSettings,
+  useColumnSettingsBasedOnColumnsType,
+} from "../table/useColumnSettingsButton.tsx";
 import {
   attachResizeToColumns,
   useTableColumnResize,
@@ -231,11 +233,14 @@ export const ActionsLog: React.FC = () => {
       : firstLine;
   };
 
-  const columns: TableProps<ActionLog>["columns"] = [
+  const columns: ColumnsTypeWithSettings<ActionLog> = [
     {
       title: "Action Time",
       key: "actionTime",
       dataIndex: "actionTime",
+      settings: {
+        visibilityLocked: true,
+      },
       width: actionLogColumnResize.columnWidths.actionTime,
       sorter: (a: ActionLog, b: ActionLog) => b.actionTime - a.actionTime,
       filterDropdown: (props: FilterDropdownProps) => (

--- a/src/components/admin_tools/ActionsLog.tsx
+++ b/src/components/admin_tools/ActionsLog.tsx
@@ -240,6 +240,7 @@ export const ActionsLog: React.FC = () => {
       dataIndex: "actionTime",
       settings: {
         visibilityLocked: true,
+        orderLocked: true,
       },
       width: actionLogColumnResize.columnWidths.actionTime,
       sorter: (a: ActionLog, b: ActionLog) => b.actionTime - a.actionTime,

--- a/src/components/admin_tools/access-control/AccessControl.tsx
+++ b/src/components/admin_tools/access-control/AccessControl.tsx
@@ -25,7 +25,6 @@ import {
   TextColumnFilterDropdown,
 } from "../../table/TextColumnFilterDropdown.tsx";
 import { useAccessControl } from "../../../hooks/useAccessControl.tsx";
-import { ColumnsType } from "antd/es/table";
 import { useModalsContext } from "../../../Modals.tsx";
 import { AbacAttributesPopUp } from "./AbacAttributesPopUp.tsx";
 import { AddDeleteRolesPopUp } from "./AddDeleteRolesPopUp.tsx";
@@ -36,7 +35,10 @@ import {
 } from "../../deployment_runtime_states/DeploymentsCumulativeState.tsx";
 import { useNotificationService } from "../../../hooks/useNotificationService.tsx";
 import { ProtectedButton } from "../../../permissions/ProtectedButton.tsx";
-import { useColumnSettingsBasedOnColumnsType } from "../../table/useColumnSettingsButton.tsx";
+import {
+  ColumnsTypeWithSettings,
+  useColumnSettingsBasedOnColumnsType,
+} from "../../table/useColumnSettingsButton.tsx";
 import {
   attachResizeToColumns,
   useTableColumnResize,
@@ -245,11 +247,15 @@ export const AccessControl: React.FC = () => {
     setSelectedRowKeys(selected);
   };
 
-  const columns: ColumnsType<AccessControlData> = [
+  const columns: ColumnsTypeWithSettings<AccessControlData> = [
     {
       title: "Endpoint",
       dataIndex: "endpoint",
       key: "endpoint",
+      settings: {
+        visibilityLocked: true,
+        orderLocked: true,
+      },
       sorter: {
         compare: (a: AccessControlData, b: AccessControlData) => {
           const aPath =

--- a/src/components/admin_tools/exchanges/LiveExchanges.tsx
+++ b/src/components/admin_tools/exchanges/LiveExchanges.tsx
@@ -7,7 +7,6 @@ import {
   Modal,
   Space,
   Table,
-  TableProps,
   Tooltip,
 } from "antd";
 import { OverridableIcon } from "../../../icons/IconProvider.tsx";
@@ -24,7 +23,10 @@ import {
 import { useNavigate } from "react-router";
 import { useLiveExchangeFilters } from "./useLiveExchangeFilters.tsx";
 import { ProtectedButton } from "../../../permissions/ProtectedButton.tsx";
-import { useColumnSettingsBasedOnColumnsType } from "../../table/useColumnSettingsButton.tsx";
+import {
+  ColumnsTypeWithSettings,
+  useColumnSettingsBasedOnColumnsType,
+} from "../../table/useColumnSettingsButton.tsx";
 import { TablePageLayout } from "../../TablePageLayout.tsx";
 import { TableToolbar } from "../../table/TableToolbar.tsx";
 import {
@@ -125,12 +127,16 @@ export const LiveExchanges: React.FC = () => {
     [terminateExchange],
   );
 
-  const columns = useMemo((): TableProps<LiveExchangeTableItem>["columns"] => {
+  const columns = useMemo((): ColumnsTypeWithSettings<LiveExchangeTableItem> => {
     return [
       {
         title: "Session ID",
         key: "sessionId",
         dataIndex: "sessionId",
+        settings: {
+          visibilityLocked: true,
+          orderLocked: true,
+        },
         sorter: (a: LiveExchangeTableItem, b: LiveExchangeTableItem) =>
           (b.sessionId ?? "").localeCompare(a.sessionId ?? ""),
         render: (_, item) =>

--- a/src/components/dev_tools/Diagnostic.tsx
+++ b/src/components/dev_tools/Diagnostic.tsx
@@ -14,7 +14,6 @@ import {
   ValidationSeverity,
   ValidationState,
 } from "../../api/apiTypes";
-import { TableProps } from "antd/lib/table";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { TableRowSelection } from "antd/lib/table/interface";
 import { api } from "../../api/api";
@@ -25,7 +24,10 @@ import { treeExpandIcon } from "../table/TreeExpandIcon";
 import { useModalsContext } from "../../Modals";
 import { DiagnosticValidationModal } from "./DiagnosticValidationModal";
 import { useDiagnosticValidationFilters } from "./useDiagnosticValidationFilters";
-import { useColumnSettingsBasedOnColumnsType } from "../table/useColumnSettingsButton";
+import {
+  ColumnsTypeWithSettings,
+  useColumnSettingsBasedOnColumnsType,
+} from "../table/useColumnSettingsButton";
 import {
   attachResizeToColumns,
   useTableColumnResize,
@@ -97,11 +99,15 @@ export const Diagnostic: React.FC = () => {
   const [searchString, setSearchString] = useState<string>("");
   const { filters, filterButton } = useDiagnosticValidationFilters();
 
-  const columns: TableProps<DiagnosticValidationTableItem>["columns"] = [
+  const columns: ColumnsTypeWithSettings<DiagnosticValidationTableItem> = [
     {
       title: "Name",
       dataIndex: "title",
       key: "title",
+      settings: {
+        visibilityLocked: true,
+        orderLocked: true,
+      },
       sorter: (a, b) => a.title.localeCompare(b.title),
       defaultSortOrder: "ascend",
       render: (_, validation) => {

--- a/src/components/table/ColumnsFilter.module.css
+++ b/src/components/table/ColumnsFilter.module.css
@@ -1,8 +1,8 @@
 .panel {
   padding: 12px;
-  background: var(--vscode-editor-background, #ffffff);
+  background: var(--vscode-editor-background, #fff);
   border: 1px solid var(--vscode-border, #d9d9d9);
-  box-shadow: var(--vscode-widget-shadow, 0 4px 12px rgba(0, 0, 0, 0.1));
+  box-shadow: var(--vscode-widget-shadow, 0 4px 12px rgb(0 0 0 / 10%));
   border-radius: 8px;
   min-width: 180px;
 }
@@ -35,7 +35,7 @@
 
 .gripOrderLocked {
   opacity: 0.35;
-  color: var(--vscode-disabledForeground, rgba(0, 0, 0, 0.35));
+  color: var(--vscode-disabledForeground, rgb(0 0 0 / 35%));
   cursor: not-allowed;
 }
 

--- a/src/components/table/ColumnsFilter.module.css
+++ b/src/components/table/ColumnsFilter.module.css
@@ -1,0 +1,49 @@
+.panel {
+  padding: 12px;
+  background: var(--vscode-editor-background, #ffffff);
+  border: 1px solid var(--vscode-border, #d9d9d9);
+  box-shadow: var(--vscode-widget-shadow, 0 4px 12px rgba(0, 0, 0, 0.1));
+  border-radius: 8px;
+  min-width: 180px;
+}
+
+.row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 6px;
+  cursor: grab;
+}
+
+.rowOrderLocked {
+  cursor: default;
+}
+
+.grip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  margin-right: 4px;
+  font-size: 20px;
+  user-select: none;
+  border-radius: 4px;
+  transition: background 0.2s;
+  cursor: grab;
+}
+
+.gripOrderLocked {
+  opacity: 0.35;
+  color: var(--vscode-disabledForeground, rgba(0, 0, 0, 0.35));
+  cursor: not-allowed;
+}
+
+.checkbox {
+  flex: 1;
+}
+
+.resetButton {
+  margin-top: 8px;
+  align-self: flex-end;
+}

--- a/src/components/table/ColumnsFilter.tsx
+++ b/src/components/table/ColumnsFilter.tsx
@@ -1,9 +1,11 @@
-import React, { useEffect, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { Button, Checkbox } from "antd";
+import clsx from "clsx";
 import { ReactSortable } from "react-sortablejs";
 import { parseJsonOrDefault } from "../../misc/json-helper";
 import { ACTIONS_COLUMN_KEY } from "./actionsColumn";
 import { clearColumnMetadata, isColumnVisibilityLocked } from "./useColumnSettingsButton";
+import styles from "./ColumnsFilter.module.css";
 
 const COLUMN_KEYS_EXCLUDED_FROM_PICKER = new Set<string>([
   ACTIONS_COLUMN_KEY,
@@ -20,16 +22,42 @@ function isVisibilityToggleDisabled(columnKey: string): boolean {
 
 type SortablePickerItem = { id: unknown };
 
+function buildOrderLockedPrefix(
+  allColumns: string[],
+  orderLockedKeySet: ReadonlySet<string>,
+): string[] {
+  return allColumns.filter((key) => orderLockedKeySet.has(key));
+}
+
+function normalizePickerColumnOrder(
+  order: string[],
+  allColumns: string[],
+  orderLockedKeySet: ReadonlySet<string>,
+): string[] {
+  const lockedPrefix = buildOrderLockedPrefix(allColumns, orderLockedKeySet);
+  if (lockedPrefix.length === 0) {
+    return order;
+  }
+  const tail = order.filter((key) => COLUMN_KEYS_EXCLUDED_FROM_PICKER.has(key));
+  const movable = order.filter(
+    (key) =>
+      !orderLockedKeySet.has(key) && !COLUMN_KEYS_EXCLUDED_FROM_PICKER.has(key),
+  );
+  return [...lockedPrefix, ...movable, ...tail];
+}
+
 function applyPickerColumnReorder(
   setColumnsOrder: React.Dispatch<React.SetStateAction<string[]>>,
   newList: readonly SortablePickerItem[],
+  allColumns: string[],
+  orderLockedKeySet: ReadonlySet<string>,
 ): void {
   const reordered = newList.map((item) => String(item.id));
   setColumnsOrder((prev) => {
-    const tail = prev.filter((k) =>
-      COLUMN_KEYS_EXCLUDED_FROM_PICKER.has(k),
-    );
-    return [...reordered, ...tail];
+    const tail = prev.filter((key) => COLUMN_KEYS_EXCLUDED_FROM_PICKER.has(key));
+    const lockedPrefix = buildOrderLockedPrefix(allColumns, orderLockedKeySet);
+    const movable = reordered.filter((key) => !orderLockedKeySet.has(key));
+    return [...lockedPrefix, ...movable, ...tail];
   });
 }
 
@@ -58,14 +86,41 @@ export const ColumnsFilter: React.FC<ColumnFilterProps> = ({
   labelsByKey,
   orderLockedKeys = [],
 }) => {
-  const orderLockedKeySet = new Set(orderLockedKeys);
+  const orderLockedKeySet = useMemo(
+    () => new Set(orderLockedKeys),
+    [orderLockedKeys],
+  );
+  const orderLockedPrefix = useMemo(
+    () => buildOrderLockedPrefix(allColumns, orderLockedKeySet),
+    [allColumns, orderLockedKeySet],
+  );
   const initialColumns =
     defaultColumns && defaultColumns.length > 0 ? defaultColumns : allColumns;
 
   const [columnsOrder, setColumnsOrder] = useState<string[]>(() => {
     const stored = localStorage.getItem(getColumnsOrderKey(storageKey));
-    return stored ? parseJsonOrDefault<string[]>(stored, []) : allColumns;
+    const order = stored ? parseJsonOrDefault<string[]>(stored, []) : allColumns;
+    return normalizePickerColumnOrder(order, allColumns, orderLockedKeySet);
   });
+
+  const handlePickerMove = useCallback(
+    (evt: { newIndex?: number; related?: Element }) => {
+      if (orderLockedPrefix.length === 0) {
+        return true;
+      }
+      if (
+        evt.newIndex !== undefined &&
+        evt.newIndex < orderLockedPrefix.length
+      ) {
+        return false;
+      }
+      if (evt.related?.classList.contains("filtered")) {
+        return false;
+      }
+      return true;
+    },
+    [orderLockedPrefix.length],
+  );
 
   const [visibleColumns, setVisibleColumns] = useState<string[]>(() => {
     const stored = localStorage.getItem(getColumnsVisibleKey(storageKey));
@@ -118,55 +173,41 @@ export const ColumnsFilter: React.FC<ColumnFilterProps> = ({
   );
 
   return (
-    <div
-      style={{
-        padding: 12,
-        background: "var(--vscode-editor-background, #ffffff)",
-        border: "1px solid var(--vscode-border, #d9d9d9)",
-        boxShadow: "var(--vscode-widget-shadow, 0 4px 12px rgba(0, 0, 0, 0.1))",
-        borderRadius: 8,
-        minWidth: 180,
-      }}
-    >
+    <div className={styles.panel}>
       <ReactSortable
         list={columnOrderForPicker.map((id) => ({ id }))}
         setList={(newList) =>
-          applyPickerColumnReorder(setColumnsOrder, newList)
+          applyPickerColumnReorder(
+            setColumnsOrder,
+            newList,
+            allColumns,
+            orderLockedKeySet,
+          )
         }
         animation={150}
         handle=".drag-handle"
         filter=".filtered"
+        onMove={handlePickerMove}
       >
-        {columnOrderForPicker.map((key) => (
+        {columnOrderForPicker.map((key) => {
+          const isOrderLocked = orderLockedKeySet.has(key);
+          return (
           <div
             key={key}
-            className={orderLockedKeySet.has(key) ? "filtered" : undefined}
-            style={{
-              display: "flex",
-              alignItems: "center",
-              gap: 8,
-              marginBottom: 6,
-              cursor: orderLockedKeySet.has(key) ? "default" : "grab",
-            }}
+            className={clsx(
+              styles.row,
+              isOrderLocked && "filtered",
+              isOrderLocked && styles.rowOrderLocked,
+            )}
           >
             <span
-              className={
-                orderLockedKeySet.has(key) ? "filtered" : "drag-handle"
-              }
-              style={{
-                cursor: orderLockedKeySet.has(key) ? "default" : "grab",
-                display: "inline-flex",
-                alignItems: "center",
-                justifyContent: "center",
-                width: 20,
-                height: 20,
-                fontSize: 20,
-                marginRight: 4,
-                userSelect: "none",
-                borderRadius: 4,
-                transition: "background 0.2s",
-              }}
-              tabIndex={0}
+              className={clsx(
+                styles.grip,
+                isOrderLocked ? "filtered" : "drag-handle",
+                isOrderLocked && styles.gripOrderLocked,
+              )}
+              aria-hidden={isOrderLocked}
+              tabIndex={isOrderLocked ? -1 : 0}
             >
               ≡
             </span>
@@ -180,17 +221,18 @@ export const ColumnsFilter: React.FC<ColumnFilterProps> = ({
                   setVisibleColumns((prev) => prev.filter((k) => k !== key));
                 }
               }}
-              style={{ flex: 1 }}
+              className={styles.checkbox}
             >
               {getLabel(key)}
             </Checkbox>
           </div>
-        ))}
+          );
+        })}
       </ReactSortable>
       <Button
         size="small"
         onClick={handleReset}
-        style={{ marginTop: 8, alignSelf: "flex-end" }}
+        className={styles.resetButton}
       >
         Reset
       </Button>

--- a/src/components/table/ColumnsFilter.tsx
+++ b/src/components/table/ColumnsFilter.tsx
@@ -39,6 +39,7 @@ export interface ColumnFilterProps {
   storageKey: string;
   onChange: (columnsOrder: string[], visibleColumns: string[]) => void;
   labelsByKey?: Record<string, string>;
+  orderLockedKeys?: string[];
 }
 
 export const getColumnsOrderKey = (storageKey: string): string => {
@@ -55,7 +56,9 @@ export const ColumnsFilter: React.FC<ColumnFilterProps> = ({
   storageKey,
   onChange,
   labelsByKey,
+  orderLockedKeys = [],
 }) => {
+  const orderLockedKeySet = new Set(orderLockedKeys);
   const initialColumns =
     defaultColumns && defaultColumns.length > 0 ? defaultColumns : allColumns;
 
@@ -132,22 +135,26 @@ export const ColumnsFilter: React.FC<ColumnFilterProps> = ({
         }
         animation={150}
         handle=".drag-handle"
+        filter=".filtered"
       >
         {columnOrderForPicker.map((key) => (
           <div
             key={key}
+            className={orderLockedKeySet.has(key) ? "filtered" : undefined}
             style={{
               display: "flex",
               alignItems: "center",
               gap: 8,
               marginBottom: 6,
-              cursor: "grab",
+              cursor: orderLockedKeySet.has(key) ? "default" : "grab",
             }}
           >
             <span
-              className="drag-handle"
+              className={
+                orderLockedKeySet.has(key) ? "filtered" : "drag-handle"
+              }
               style={{
-                cursor: "grab",
+                cursor: orderLockedKeySet.has(key) ? "default" : "grab",
                 display: "inline-flex",
                 alignItems: "center",
                 justifyContent: "center",

--- a/src/components/table/useColumnSettingsButton.tsx
+++ b/src/components/table/useColumnSettingsButton.tsx
@@ -9,6 +9,7 @@ export type ColumnsTypeWithSettings<T> = ColumnTypeWithSettings<T>[];
 
 export type ColumnSettings = {
   visibilityLocked?: boolean;
+  orderLocked?: boolean;
 };
 
 export type ColumnTypeWithSettings<T> = ColumnType<T> & {
@@ -37,6 +38,7 @@ export const useColumnSettingsButton = <T,>(
   allColumnKeys: string[],
   visibleKeys: string[],
   tableColumnDefinitions: ColumnsType<T>,
+  orderLockedKeys: string[] = [],
 ) => {
   const allColumnKeysMemo = useMemo(() => {
     const storedOrder = localStorage.getItem(getColumnsOrderKey(storageKey));
@@ -107,6 +109,7 @@ export const useColumnSettingsButton = <T,>(
         tableColumnDefinitions.map((c) => [c.key as string, c.title as string]),
       )}
       onChange={handleColumnsChange}
+      orderLockedKeys={orderLockedKeys}
     />
   );
   return { orderedColumns, columnSettingsButton };
@@ -124,10 +127,15 @@ export const useColumnSettingsBasedOnColumnsType = <T,>(
     .filter((columnType) => columnType.key && columnType.hidden !== true)
     .map((columnType) => buildKeyWithMetadata(columnType));
 
+  const orderLockedKeys = tableColumnDefinitions
+    .filter((columnType) => columnType.settings?.orderLocked)
+    .map((columnType) => buildKeyWithMetadata(columnType));
+
   return useColumnSettingsButton(
     storageKey,
     allColumnKeys,
     visibleColumns,
     tableColumnDefinitions,
+    orderLockedKeys,
   );
 };

--- a/tests/components/table/ColumnsFilter.test.tsx
+++ b/tests/components/table/ColumnsFilter.test.tsx
@@ -206,7 +206,7 @@ describe("ColumnsFilter", () => {
     });
   });
 
-  it("normalizes stored order so order-locked columns are first on load", async () => {
+  it("moves order-locked columns first on load without changing other column order", async () => {
     const onChange = jest.fn();
     localStorage.setItem(
       getColumnsOrderKey(STORAGE_KEY),
@@ -229,7 +229,7 @@ describe("ColumnsFilter", () => {
       const stored = JSON.parse(
         localStorage.getItem(getColumnsOrderKey(STORAGE_KEY))!,
       ) as string[];
-      expect(stored).toEqual(["id*", "name", "status"]);
+      expect(stored).toEqual(["id*", "status", "name"]);
     });
   });
 

--- a/tests/components/table/ColumnsFilter.test.tsx
+++ b/tests/components/table/ColumnsFilter.test.tsx
@@ -185,6 +185,54 @@ describe("ColumnsFilter", () => {
     );
   });
 
+  it("keeps order-locked columns first after picker reorder", async () => {
+    const onChange = jest.fn();
+    render(
+      <ColumnsFilter
+        allColumns={["actionTime*", "username", "operation"]}
+        defaultColumns={["actionTime*", "username", "operation"]}
+        storageKey={STORAGE_KEY}
+        onChange={onChange}
+        orderLockedKeys={["actionTime*"]}
+        labelsByKey={{ "actionTime*": "Action Time" }}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("simulate-picker-reorder"));
+    await waitFor(() => {
+      const stored = JSON.parse(
+        localStorage.getItem(getColumnsOrderKey(STORAGE_KEY))!,
+      ) as string[];
+      expect(stored).toEqual(["actionTime*", "operation", "username"]);
+    });
+  });
+
+  it("normalizes stored order so order-locked columns are first on load", async () => {
+    const onChange = jest.fn();
+    localStorage.setItem(
+      getColumnsOrderKey(STORAGE_KEY),
+      JSON.stringify(["status", "id*", "name"]),
+    );
+    localStorage.setItem(
+      getColumnsVisibleKey(STORAGE_KEY),
+      JSON.stringify(["id*", "name", "status"]),
+    );
+    render(
+      <ColumnsFilter
+        allColumns={["id*", "name", "status"]}
+        defaultColumns={["id*", "name", "status"]}
+        storageKey={STORAGE_KEY}
+        onChange={onChange}
+        orderLockedKeys={["id*"]}
+      />,
+    );
+    await waitFor(() => {
+      const stored = JSON.parse(
+        localStorage.getItem(getColumnsOrderKey(STORAGE_KEY))!,
+      ) as string[];
+      expect(stored).toEqual(["id*", "name", "status"]);
+    });
+  });
+
   it("merges picker reorder with excluded tail keys (e.g. actions)", async () => {
     const onChange = jest.fn();
     render(

--- a/tests/components/table/ColumnsFilter.test.tsx
+++ b/tests/components/table/ColumnsFilter.test.tsx
@@ -113,6 +113,24 @@ describe("ColumnsFilter", () => {
     expect(screen.getByRole("checkbox", { name: /locked col/i })).toBeDisabled();
   });
 
+  it("keeps Action Time checked and not toggleable when visibility-locked (Audit)", () => {
+    const onChange = jest.fn();
+    render(
+      <ColumnsFilter
+        allColumns={["actionTime*", "username", "operation"]}
+        defaultColumns={["actionTime*", "username", "operation"]}
+        storageKey={STORAGE_KEY}
+        onChange={onChange}
+        labelsByKey={{ "actionTime*": "Action Time" }}
+      />,
+    );
+    const actionTime = screen.getByRole("checkbox", { name: /action time/i });
+    expect(actionTime).toBeDisabled();
+    expect(actionTime).toBeChecked();
+    fireEvent.click(actionTime);
+    expect(actionTime).toBeChecked();
+  });
+
   it("updates visibility when a toggleable column is unchecked", async () => {
     const onChange = jest.fn();
     render(

--- a/tests/components/table/useColumnSettingsButton.test.tsx
+++ b/tests/components/table/useColumnSettingsButton.test.tsx
@@ -6,8 +6,23 @@ import "@testing-library/jest-dom";
 import { render, screen } from "@testing-library/react";
 import { ColumnsType } from "antd/lib/table";
 import React from "react";
-import { ColumnsFilter } from "../../../src/components/table/ColumnsFilter";
-import { useColumnSettingsButton } from "../../../src/components/table/useColumnSettingsButton";
+import {
+  ColumnFilterProps,
+  ColumnsFilter,
+} from "../../../src/components/table/ColumnsFilter";
+import {
+  useColumnSettingsBasedOnColumnsType,
+  useColumnSettingsButton,
+} from "../../../src/components/table/useColumnSettingsButton";
+
+let latestColumnSettingsProps: ColumnFilterProps | undefined;
+
+jest.mock("../../../src/components/table/ColumnSettingsButton", () => ({
+  ColumnSettingsButton: (props: ColumnFilterProps) => {
+    latestColumnSettingsProps = props;
+    return <button type="button">column-settings</button>;
+  },
+}));
 
 // src/components/table/useColumnSettingsButton.test.tsx
 // Mock getColumnsOrderKey and getColumnsVisibleKey from ColumnsFilter
@@ -29,6 +44,7 @@ jest.mock<typeof ColumnsFilter>(
 beforeEach(() => {
   localStorage.clear();
   jest.clearAllMocks();
+  latestColumnSettingsProps = undefined;
 });
 
 // Integration tests for useColumnSettingsButton
@@ -390,6 +406,42 @@ describe("useColumnSettingsButton() useColumnSettingsButton method", () => {
         }
         render(<TestComponent />);
       }).not.toThrow();
+    });
+  });
+});
+
+describe("useColumnSettingsBasedOnColumnsType visibilityLocked", () => {
+  it("passes actionTime* key for Action Time when visibilityLocked is set", () => {
+    const tableColumnDefinitions = [
+      {
+        key: "actionTime",
+        title: "Action Time",
+        settings: { visibilityLocked: true },
+      },
+      { key: "username", title: "Initiator" },
+    ];
+
+    function TestComponent() {
+      const { columnSettingsButton } = useColumnSettingsBasedOnColumnsType(
+        "actionsLogTable",
+        tableColumnDefinitions,
+      );
+      return <div>{columnSettingsButton}</div>;
+    }
+
+    render(<TestComponent />);
+
+    expect(latestColumnSettingsProps?.allColumns).toEqual([
+      "actionTime*",
+      "username",
+    ]);
+    expect(latestColumnSettingsProps?.defaultColumns).toEqual([
+      "actionTime*",
+      "username",
+    ]);
+    expect(latestColumnSettingsProps?.labelsByKey).toEqual({
+      actionTime: "Action Time",
+      username: "Initiator",
     });
   });
 });


### PR DESCRIPTION
**Problem Description**

- Users could hide or move mandatory columns in _Audit, Access Control, Live Exchanges, and Diagnostic_ settings, even though it is mandatory for the table.

**Solution Description**

- Add `visibilityLocked: true` to the mandatory columns in Audit, Access Control, Live Exchanges, and Diagnostic which appends * to the storage key; checkbox disabled in the picker
- Implement and add `orderLocked: true` to the mandatory columns in Audit, Access Control, Live Exchanges, and Diagnostic so that column cannot be dragged and stays at the top of the picker order (definition order in allColumns)
- Picker layout moved from inline styles to a CSS module (aligned with `TableToolbar.module.css`).
- gripOrderLocked class to add greyed grip (opacity, disabled foreground color, cursor: not-allowed).

Additional details:
`filter=".filtered"`  -> Cannot start a drag on order-locked rows
`onMove` -> Blocks dropping other columns before locked slots (required because even after filtered, the other items were allowed to move beyond the locked column).
Check this to understand default behaviour and why onMove was required. https://sortablejs.github.io/Sortable/