### PR TITLE
fix(graph): set node selected when focusing from Properties panel #680

### DIFF
--- a/src/components/graph/ElementFocus.tsx
+++ b/src/components/graph/ElementFocus.tsx
@@ -1,7 +1,13 @@
-import React, { useContext, useEffect } from "react";
-import { useReactFlow } from "@xyflow/react";
+import React, { useCallback, useContext, useEffect } from "react";
+import { Node, useReactFlow } from "@xyflow/react";
 
 export type FitViewToElementIdFn = (id: string) => void;
+
+const withSingleNodeSelected = <T extends Node>(nodes: T[], selectedId: string): T[] =>
+  nodes.map((node) => ({
+    ...node,
+    selected: node.id === selectedId,
+  }));
 
 export const ElementFocusContext =
   React.createContext<React.MutableRefObject<FitViewToElementIdFn | null> | null>(
@@ -27,28 +33,28 @@ export const ElementFocus = () => {
   const ref = useElementFocusRef();
   const { fitView, getNodes, setNodes } = useReactFlow();
 
-  useEffect(() => {
-    ref.current = (id: string) => {
+  const focusToElementId = useCallback<FitViewToElementIdFn>(
+    (id) => {
       const nodes = getNodes();
       if (!nodes.some((n) => n.id === id)) return;
 
-      setNodes((currentNodes) =>
-        currentNodes.map((node) => ({
-          ...node,
-          selected: node.id === id,
-        })),
-      );
+      setNodes((currentNodes) => withSingleNodeSelected(currentNodes, id));
 
       fitView({
         nodes: [{ id }],
         padding: 0.2,
         duration: 300,
       });
-    };
+    },
+    [fitView, getNodes, setNodes],
+  );
+
+  useEffect(() => {
+    ref.current = focusToElementId;
     return () => {
       ref.current = null;
     };
-  }, [ref, fitView, getNodes, setNodes]);
+  }, [ref, focusToElementId]);
 
   return null;
 };

--- a/src/components/graph/ElementFocus.tsx
+++ b/src/components/graph/ElementFocus.tsx
@@ -25,12 +25,20 @@ export const useFocusToElementId = (): FitViewToElementIdFn => {
 
 export const ElementFocus = () => {
   const ref = useElementFocusRef();
-  const { fitView, getNodes } = useReactFlow();
+  const { fitView, getNodes, setNodes } = useReactFlow();
 
   useEffect(() => {
     ref.current = (id: string) => {
       const nodes = getNodes();
       if (!nodes.some((n) => n.id === id)) return;
+
+      setNodes((currentNodes) =>
+        currentNodes.map((node) => ({
+          ...node,
+          selected: node.id === id,
+        })),
+      );
+
       fitView({
         nodes: [{ id }],
         padding: 0.2,
@@ -40,7 +48,7 @@ export const ElementFocus = () => {
     return () => {
       ref.current = null;
     };
-  }, [ref, fitView, getNodes]);
+  }, [ref, fitView, getNodes, setNodes]);
 
   return null;
 };

--- a/tests/components/graph/ElementFocus.test.tsx
+++ b/tests/components/graph/ElementFocus.test.tsx
@@ -1,0 +1,135 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import React from "react";
+import { render, act, renderHook } from "@testing-library/react";
+import {
+  ElementFocus,
+  ElementFocusContext,
+  useElementFocusRef,
+  useFocusToElementId,
+  type FitViewToElementIdFn,
+} from "../../../src/components/graph/ElementFocus";
+
+const mockFitView = jest.fn();
+const mockGetNodes = jest.fn();
+const mockSetNodes = jest.fn();
+
+jest.mock("@xyflow/react", () => ({
+  useReactFlow: () => ({
+    fitView: mockFitView,
+    getNodes: mockGetNodes,
+    setNodes: mockSetNodes,
+  }),
+}));
+
+const renderElementFocus = () => {
+  const focusRef = { current: null as FitViewToElementIdFn | null };
+  render(
+    <ElementFocusContext.Provider value={focusRef}>
+      <ElementFocus />
+    </ElementFocusContext.Provider>,
+  );
+  return focusRef;
+};
+
+describe("ElementFocus", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetNodes.mockReturnValue([
+      { id: "node-a", selected: false },
+      { id: "node-b", selected: false },
+    ]);
+  });
+
+  it("registers a handler that selects the node and fits the view", () => {
+    const focusRef = renderElementFocus();
+
+    act(() => {
+      focusRef.current?.("node-b");
+    });
+
+    expect(mockSetNodes).toHaveBeenCalledTimes(1);
+    const updater = mockSetNodes.mock.calls[0][0] as (
+      nodes: { id: string; selected: boolean }[],
+    ) => { id: string; selected: boolean }[];
+    expect(
+      updater([
+        { id: "node-a", selected: false },
+        { id: "node-b", selected: false },
+      ]),
+    ).toEqual([
+      { id: "node-a", selected: false },
+      { id: "node-b", selected: true },
+    ]);
+
+    expect(mockFitView).toHaveBeenCalledWith({
+      nodes: [{ id: "node-b" }],
+      padding: 0.2,
+      duration: 300,
+    });
+  });
+
+  it("does nothing when the element id is not on the graph", () => {
+    mockGetNodes.mockReturnValue([{ id: "node-a", selected: false }]);
+    const focusRef = renderElementFocus();
+
+    act(() => {
+      focusRef.current?.("missing-node");
+    });
+
+    expect(mockSetNodes).not.toHaveBeenCalled();
+    expect(mockFitView).not.toHaveBeenCalled();
+  });
+
+  it("clears the handler on unmount", () => {
+    const focusRef = { current: null as FitViewToElementIdFn | null };
+    const { unmount } = render(
+      <ElementFocusContext.Provider value={focusRef}>
+        <ElementFocus />
+      </ElementFocusContext.Provider>,
+    );
+
+    expect(focusRef.current).not.toBeNull();
+
+    unmount();
+
+    expect(focusRef.current).toBeNull();
+  });
+});
+
+describe("useFocusToElementId", () => {
+  it("delegates to the context ref handler", () => {
+    const handler = jest.fn();
+    const focusRef = { current: handler };
+
+    const { result } = renderHook(() => useFocusToElementId(), {
+      wrapper: ({ children }) => (
+        <ElementFocusContext.Provider value={focusRef}>
+          {children}
+        </ElementFocusContext.Provider>
+      ),
+    });
+
+    act(() => {
+      result.current("node-1");
+    });
+
+    expect(handler).toHaveBeenCalledWith("node-1");
+  });
+});
+
+describe("useElementFocusRef", () => {
+  it("throws when used outside ElementFocusContext.Provider", () => {
+    const consoleError = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    expect(() => renderHook(() => useElementFocusRef())).toThrow(
+      "useElementFocusRef must be used within ElementFocusContext.Provider",
+    );
+
+    consoleError.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
Fixes graph node highlighting when an element is selected from the QIP Configuration graph UI right panel (Properties tab and elements list).

## Problem 
Selecting an element in the Properties table (or elements list) did not highlight the matching node on the chain graph. The panel could show selection, but graph nodes looked unchanged.

## Root cause
`focusToElementId `(via `ElementFocus`) only called fitView to pan/zoom to the node. It did not set React Flow’s selected state, which drives selection styling (.react-flow__node.selected).

## Solution
Update `ElementFocus `to set `selected: true` on the target node and clear selection on others before calling `fitView`.