### PR TITLE
fix(ui): lock identifier columns in column settings picker #684

### DIFF
--- a/src/components/admin_tools/ImportInstructions.tsx
+++ b/src/components/admin_tools/ImportInstructions.tsx
@@ -418,6 +418,7 @@ export const ImportInstructions: React.FC = () => {
         key: "id",
         settings: {
           visibilityLocked: true,
+          orderLocked: true,
         },
         width: 280,
         sorter: (a, b) =>

--- a/src/components/admin_tools/design-templates/DesignTemplates.tsx
+++ b/src/components/admin_tools/design-templates/DesignTemplates.tsx
@@ -9,8 +9,10 @@ import { useModalsContext } from "../../../Modals";
 import { CreateDesignTemplateModal } from "./CreateDesignTemplateModal";
 import { TableRowSelection } from "antd/es/table/interface";
 import { ProtectedButton } from "../../../permissions/ProtectedButton.tsx";
-import { useColumnSettingsBasedOnColumnsType } from "../../table/useColumnSettingsButton";
-import { ColumnsType } from "antd/lib/table";
+import {
+  ColumnsTypeWithSettings,
+  useColumnSettingsBasedOnColumnsType,
+} from "../../table/useColumnSettingsButton";
 import {
   attachResizeToColumns,
   useTableColumnResize,
@@ -47,11 +49,15 @@ export const DesignTemplates: React.FC = () => {
     [tableData, searchTerm],
   );
 
-  const columns: ColumnsType<DetailedDesignTemplate> = [
+  const columns: ColumnsTypeWithSettings<DetailedDesignTemplate> = [
     {
       title: "Name",
       dataIndex: "name",
       key: "name",
+      settings: {
+        visibilityLocked: true,
+        orderLocked: true,
+      },
       sorter: (a, b) => a.name.localeCompare(b.name),
       defaultSortOrder: "ascend",
     },

--- a/src/components/admin_tools/domains/DomainsTable.tsx
+++ b/src/components/admin_tools/domains/DomainsTable.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { Flex, Table, Button, Space, Tag, Typography } from "antd";
-import type { ColumnsType } from "antd/es/table";
 import { EngineTable } from "./EngineTable";
 import { useEngines } from "./hooks/useEngines";
 import { treeExpandIcon } from "../../table/TreeExpandIcon";
@@ -8,7 +7,10 @@ import { DomainType, EngineDomain } from "../../../api/apiTypes.ts";
 import { OverridableIcon } from "../../../icons/IconProvider.tsx";
 import { useNotificationService } from "../../../hooks/useNotificationService.tsx";
 import { api } from "../../../api/api.ts";
-import { useColumnSettingsBasedOnColumnsType } from "../../table/useColumnSettingsButton.tsx";
+import {
+  ColumnsTypeWithSettings,
+  useColumnSettingsBasedOnColumnsType,
+} from "../../table/useColumnSettingsButton.tsx";
 import {
   attachResizeToColumns,
   sumScrollXForColumns,
@@ -91,12 +93,16 @@ const DomainsTable: React.FC<Props> = ({ domains, isLoading = false }) => {
     [notificationsService],
   );
 
-  const columns: ColumnsType<EngineDomain> = useMemo(
+  const columns: ColumnsTypeWithSettings<EngineDomain> = useMemo(
     () => [
       {
         title: "Domain",
         dataIndex: "name",
         key: "name",
+        settings: {
+          visibilityLocked: true,
+          orderLocked: true,
+        },
         render: (_: unknown, domain: EngineDomain) => {
           return domain.type === DomainType.MICRO ? (
             <Space size={"small"}>

--- a/src/components/services/ServicesTreeTable.tsx
+++ b/src/components/services/ServicesTreeTable.tsx
@@ -614,6 +614,7 @@ export function useServicesTreeTable<T extends ServiceEntity = ServiceEntity>({
         allServicesTreeTableColumns.map((c) => [c.key, c.title]),
       )}
       onChange={handleColumnsChange}
+      orderLockedKeys={["name"]}
     />
   );
 

--- a/src/components/services/context/ContextServiceList.tsx
+++ b/src/components/services/context/ContextServiceList.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from "react";
-import { Button, message, Modal, Table, TableProps } from "antd";
+import { Button, message, Modal, Table } from "antd";
 import { useNavigate } from "react-router-dom";
 import { api } from "../../../api/api";
 import { IntegrationSystemType } from "../../../api/apiTypes";
@@ -20,7 +20,10 @@ import { InlineEdit } from "../../InlineEdit.tsx";
 import { LabelsEdit } from "../../table/LabelsEdit.tsx";
 import { formatOptional, formatTimestamp } from "../../../misc/format-utils.ts";
 import { ProtectedDropdown } from "../../../permissions/ProtectedDropdown.tsx";
-import { useColumnSettingsBasedOnColumnsType } from "../../table/useColumnSettingsButton.tsx";
+import {
+  ColumnsTypeWithSettings,
+  useColumnSettingsBasedOnColumnsType,
+} from "../../table/useColumnSettingsButton.tsx";
 import { ChainColumn } from "../ui/ChainColumn.tsx";
 import { useColumnsWithResizeAndScroll } from "../../table/useColumnsWithResizeAndScroll.tsx";
 
@@ -67,11 +70,15 @@ export const ContextServiceList: React.FC = () => {
     }
   }, [loadingError, notificationService]);
 
-  const columns: TableProps<ContextSystem>["columns"] = [
+  const columns: ColumnsTypeWithSettings<ContextSystem> = [
     {
       title: "Name",
       dataIndex: "name",
       key: "name",
+      settings: {
+        visibilityLocked: true,
+        orderLocked: true,
+      },
       width: 200,
       minWidth: 120,
       render: (_: unknown, system) => (

--- a/src/components/services/mcp/McpServiceList.tsx
+++ b/src/components/services/mcp/McpServiceList.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { GenericServiceListPage } from "../GenericServiceListPage.tsx";
 import { OverridableIcon } from "../../../icons/IconProvider.tsx";
-import { Button, message, Table, TableProps } from "antd";
+import { Button, message, Table } from "antd";
 import {
   IntegrationSystemType,
   MCPSystem,
@@ -22,7 +22,10 @@ import { LabelsEdit } from "../../table/LabelsEdit.tsx";
 import { ProtectedDropdown } from "../../../permissions/ProtectedDropdown.tsx";
 import { downloadFile } from "../../../misc/download-utils.ts";
 import { toStringIds } from "../../../misc/selection-utils.ts";
-import { useColumnSettingsBasedOnColumnsType } from "../../table/useColumnSettingsButton.tsx";
+import {
+  ColumnsTypeWithSettings,
+  useColumnSettingsBasedOnColumnsType,
+} from "../../table/useColumnSettingsButton.tsx";
 import {
   attachResizeToColumns,
   sumScrollXForColumns,
@@ -131,11 +134,15 @@ export const McpServiceList: React.FC = () => {
     void loadSystems();
   }, [loadSystems]);
 
-  const columns: TableProps<MCPSystem>["columns"] = [
+  const columns: ColumnsTypeWithSettings<MCPSystem> = [
     {
       title: "Name",
       dataIndex: "name",
       key: "name",
+      settings: {
+        visibilityLocked: true,
+        orderLocked: true,
+      },
       width: 200,
       minWidth: 120,
       render: (_: unknown, system) => (

--- a/src/pages/Chains.tsx
+++ b/src/pages/Chains.tsx
@@ -13,7 +13,6 @@ import {
 } from "../api/apiTypes.ts";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { api } from "../api/api.ts";
-import { TableProps } from "antd/lib/table";
 import { formatTimestamp } from "../misc/format-utils.ts";
 import { EntityLabels } from "../components/labels/EntityLabels.tsx";
 import { TableRowSelection } from "antd/lib/table/interface";
@@ -50,7 +49,10 @@ import {
   ProtectedMenuItem,
 } from "../permissions/ProtectedDropdown.tsx";
 import { MenuInfo } from "rc-menu/lib/interface";
-import { useColumnSettingsBasedOnColumnsType } from "../components/table/useColumnSettingsButton.tsx";
+import {
+  ColumnsTypeWithSettings,
+  useColumnSettingsBasedOnColumnsType,
+} from "../components/table/useColumnSettingsButton.tsx";
 import { useTableDragDrop } from "../hooks/useTableDragDrop.ts";
 import { treeExpandIcon } from "../components/table/TreeExpandIcon.tsx";
 import {
@@ -958,11 +960,15 @@ const Chains = () => {
     { label: "Delete", key: "deleteChain", require: { chain: ["delete"] } },
   ];
 
-  const columns: TableProps<ChainTableItem>["columns"] = [
+  const columns: ColumnsTypeWithSettings<ChainTableItem> = [
     {
       title: "Name",
       key: "name",
       dataIndex: "name",
+      settings: {
+        visibilityLocked: true,
+        orderLocked: true,
+      },
       sorter: compareChainTableItemsByTypeAndName,
       render: (_, item) => (
         <Flex vertical={false} gap={4}>

--- a/src/pages/Sessions.tsx
+++ b/src/pages/Sessions.tsx
@@ -7,7 +7,6 @@ import React, {
 } from "react";
 import { Flex, message, Table } from "antd";
 import { useNavigate, useParams } from "react-router";
-import { ColumnsType } from "antd/lib/table";
 import {
   Checkpoint,
   CheckpointSession,
@@ -53,7 +52,10 @@ import { filterOutByIds, toStringIds } from "../misc/selection-utils.ts";
 import { useRegisterChainHeaderActions } from "./ChainHeaderActionsContext.tsx";
 import { confirmAndRun } from "../misc/confirm-utils.ts";
 import { ProtectedButton } from "../permissions/ProtectedButton.tsx";
-import { useColumnSettingsBasedOnColumnsType } from "../components/table/useColumnSettingsButton.tsx";
+import {
+  ColumnsTypeWithSettings,
+  useColumnSettingsBasedOnColumnsType,
+} from "../components/table/useColumnSettingsButton.tsx";
 import {
   attachResizeToColumns,
   sumScrollXForColumns,
@@ -336,12 +338,16 @@ export const Sessions: React.FC<SessionsProps> = ({
     [messageApi, notificationService],
   );
 
-  const tableColumnDefinitions = useMemo<ColumnsType<SessionTableItem>>(
+  const tableColumnDefinitions = useMemo<ColumnsTypeWithSettings<SessionTableItem>>(
     () => [
       {
         title: "ID",
         dataIndex: "id",
         key: "id",
+        settings: {
+          visibilityLocked: true,
+          orderLocked: true,
+        },
         render: (_, item) =>
           isCorrelationItem(item) ? (
             <span style={{ fontWeight: 600 }}>{item.id}</span>


### PR DESCRIPTION
Prevent reordering of primary identifier columns via settings.orderLocked and visibilityLocked on 

- Chains (Name), 
- Services MCP/Context (Name), 
- Services tree tables (Name), 
- admin pages (Design Templates, Sessions, Import Instructions, Domains).